### PR TITLE
Accept cookies for Google before searching

### DIFF
--- a/fake_traffic/fake_traffic.py
+++ b/fake_traffic/fake_traffic.py
@@ -73,6 +73,9 @@ class FakeTraffic:
                 search_urls = []
                 try:
                     await page.goto("https://www.google.com", wait_until="load")
+                    accept_all = await page.is_visible("#L2AGLb")
+                    if accept_all:
+                        await page.click("#L2AGLb")
                     await page.fill('textarea[name="q"]', keyword)
                     await page.press('textarea[name="q"]', "Enter")
                     # pagination


### PR DESCRIPTION
When running a command like this: 

```sh
fake_traffic -nh -c us -k "example"
```

It hangs on the screen:

<img width="761" alt="Cookies" src="https://github.com/user-attachments/assets/dd2ee8ee-14fd-4094-bbd0-33b9ab49136c" />

The `await page.click("#L2AGLb")` accepts the button and continue the process.

@deedy5 Could you please review? Thanks
